### PR TITLE
Feature/edit

### DIFF
--- a/ClassLibrary/AVL.cs
+++ b/ClassLibrary/AVL.cs
@@ -10,6 +10,7 @@ namespace ClassLibrary
         public int count;
         public List<T> NodeList;
         Func<T, T, int> Comparer;
+        
 
         public AVL(Func<T, T, int> Comparer)
         {
@@ -19,6 +20,8 @@ namespace ClassLibrary
             this.Comparer = Comparer;
 
         }
+
+       
 
         public Node<T> Insert(Node<T> root, Node<T> newNode)
         {
@@ -157,5 +160,8 @@ namespace ClassLibrary
             }
             return false;
         }
+
+
+        
     }
 }

--- a/ClassLibrary/ConsultationDay.cs
+++ b/ClassLibrary/ConsultationDay.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClassLibrary
+{
+    public class ConsultationDay
+    {
+        public string Date { get; set; }
+        public List<Patient> PatientList { get; set; }
+        
+    }
+}

--- a/ClassLibrary/ConsultationDay.cs
+++ b/ClassLibrary/ConsultationDay.cs
@@ -6,8 +6,14 @@ namespace ClassLibrary
 {
     public class ConsultationDay
     {
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
         public List<Patient> PatientList { get; set; }
+
+        public ConsultationDay (DateTime date)
+        {
+            PatientList = new List<Patient>();
+            Date = date;
+        }
         
     }
 }

--- a/PROJECT-ED1/Controllers/DentalClinicController.cs
+++ b/PROJECT-ED1/Controllers/DentalClinicController.cs
@@ -47,12 +47,42 @@ namespace PROJECT_ED1.Controllers
                     NextConsultation = Convert.ToDateTime(collection["NextConsultation"]),
                     TreatmentDescription = collection["TreatmentDescription"]
 
-                };
+                };            
+                
 
                 Node<Patient> NewNodeDPI = new Node<Patient>(patient);
                 Node<Patient> NewNodeName = new Node<Patient>(patient);
+                
 
-                if(!Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
+                if (patient.NextConsultation != default(DateTime))
+                {
+                    ConsultationDay consultationDay = new ConsultationDay(patient.NextConsultation);
+                    consultationDay.PatientList.Add(patient);
+                    Node<ConsultationDay> newNodeConsultationDay = new Node<ConsultationDay>(consultationDay);
+
+                    if (!Data.Instance.ConsultationDayTree.Contains(Data.Instance.ConsultationDayTree.Root, newNodeConsultationDay) && !Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
+                    {
+                        
+                        Data.Instance.ConsultationDayTree.Root = Data.Instance.ConsultationDayTree.Insert(Data.Instance.ConsultationDayTree.Root, newNodeConsultationDay);
+                    }
+                    else
+                    {
+                        
+                        var aux = Data.Instance.ConsultationDayTree.Search(Data.Instance.ConsultationDayTree.Root, newNodeConsultationDay);
+
+                        if (Data.Instance.ConsultationDayTree.Search(Data.Instance.ConsultationDayTree.Root, newNodeConsultationDay).Record.PatientList.Count <= 8 && !Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
+                            Data.Instance.ConsultationDayTree.Search(Data.Instance.ConsultationDayTree.Root, newNodeConsultationDay).Record.PatientList.Add(patient);
+                        else if (!Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
+                        {
+                            ViewBag.AddPatientToConsultationDay = "The consultation day you are trying to access is already full of patients, try again with another date";
+                            return View();
+                        }
+                            
+                    }
+                }
+
+
+                if (!Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
                 { 
                     Data.Instance.DPITree.Root = Data.Instance.DPITree.Insert(Data.Instance.DPITree.Root, NewNodeDPI);   //Call to insert to DPI TREE function
                     Data.Instance.NameTree.Root = Data.Instance.NameTree.Insert(Data.Instance.NameTree.Root, NewNodeName);   //Call to insert to NAME TREE function

--- a/PROJECT-ED1/Controllers/DentalClinicController.cs
+++ b/PROJECT-ED1/Controllers/DentalClinicController.cs
@@ -54,14 +54,14 @@ namespace PROJECT_ED1.Controllers
 
                 if(!Data.Instance.DPITree.Contains(Data.Instance.DPITree.Root, NewNodeDPI) && !Data.Instance.NameTree.Contains(Data.Instance.NameTree.Root, NewNodeName))
                 { 
-                Data.Instance.DPITree.Root = Data.Instance.DPITree.Insert(Data.Instance.DPITree.Root, NewNodeDPI);   //Call to insert to DPI TREE function
-                Data.Instance.NameTree.Root = Data.Instance.NameTree.Insert(Data.Instance.NameTree.Root, NewNodeName);   //Call to insert to NAME TREE function
+                    Data.Instance.DPITree.Root = Data.Instance.DPITree.Insert(Data.Instance.DPITree.Root, NewNodeDPI);   //Call to insert to DPI TREE function
+                    Data.Instance.NameTree.Root = Data.Instance.NameTree.Insert(Data.Instance.NameTree.Root, NewNodeName);   //Call to insert to NAME TREE function
 
-                //Clear list
-                Data.Instance.DPITree.NodeList.Clear();
+                    //Clear list
+                    Data.Instance.DPITree.NodeList.Clear();
 
-                //Fill list
-                Data.Instance.DPITree.InOrder(Data.Instance.DPITree.Root);
+                    //Fill list
+                    Data.Instance.DPITree.InOrder(Data.Instance.DPITree.Root);
 
                     return RedirectToAction(nameof(Index));
                 }

--- a/PROJECT-ED1/Helpers/Data.cs
+++ b/PROJECT-ED1/Helpers/Data.cs
@@ -33,8 +33,15 @@ namespace PROJECT_ED1.Helpers
             return patient.FullName.ToLower().CompareTo(newPatient.FullName.ToLower());
         };  //Compares two patient nodes by their Name
 
+
+        public static Func<ConsultationDay, ConsultationDay, int> ConsultationDayComparer = (day, newDay) =>
+        {
+            return day.Date.CompareTo(newDay.Date);
+        }; //Compares two ConsultationDay nodes by their date
+
         public AVL<Patient> DPITree = new AVL<Patient>(DPIcomparer);
         public AVL<Patient> NameTree = new AVL<Patient>(NameComparer);
+        public AVL<ConsultationDay> ConsultationDayTree = new AVL<ConsultationDay>(ConsultationDayComparer);
 
     }
 }

--- a/PROJECT-ED1/Helpers/Data.cs
+++ b/PROJECT-ED1/Helpers/Data.cs
@@ -36,8 +36,12 @@ namespace PROJECT_ED1.Helpers
 
         public static Func<ConsultationDay, ConsultationDay, int> ConsultationDayComparer = (day, newDay) =>
         {
-            return day.Date.CompareTo(newDay.Date);
+            //return day.Date.CompareTo(newDay.Date);
+            return DateTime.Compare(day.Date, newDay.Date);
         }; //Compares two ConsultationDay nodes by their date
+
+       
+
 
         public AVL<Patient> DPITree = new AVL<Patient>(DPIcomparer);
         public AVL<Patient> NameTree = new AVL<Patient>(NameComparer);

--- a/PROJECT-ED1/Views/DentalClinic/Create.cshtml
+++ b/PROJECT-ED1/Views/DentalClinic/Create.cshtml
@@ -16,6 +16,18 @@
     }
 }
 
+
+@{ 
+    if (ViewBag.AddPatientToConsultationDay != null)
+    {
+        <div class="alert alert-danger alert-dismissible">
+            <a href="#" class="close" data-dismiss="alert" aria-label="close">×</a>
+            @ViewBag.AddPatientToConsultationDay
+        </div>
+    }
+}
+
+
 @{
     string day = DateTime.Now.Day.ToString();
     string month = DateTime.Now.Month.ToString();

--- a/PROJECT-ED1/Views/DentalClinic/Filter.cshtml
+++ b/PROJECT-ED1/Views/DentalClinic/Filter.cshtml
@@ -56,7 +56,7 @@
             </td>
             <td>
                 @{
-                    if (item.NextConsultation.Year.ToString() != "1")
+                    if (item.NextConsultation != default(DateTime))
                         @Html.DisplayFor(modelItem => item.NextConsultation);
                 }
             </td>

--- a/PROJECT-ED1/Views/DentalClinic/Index.cshtml
+++ b/PROJECT-ED1/Views/DentalClinic/Index.cshtml
@@ -66,7 +66,7 @@
             </td>
             <td>
                 @{
-                    if (item.NextConsultation.Year.ToString() != "1")
+                    if (item.NextConsultation != default(DateTime))
                         @Html.DisplayFor(modelItem => item.NextConsultation);
                 }
                 


### PR DESCRIPTION
Cambios hechos:
- Implementación del tercer AVL para el almacenamiento de días de consulta agregada
- Las condicionales para evaluar una fecha de futura consulta no especificada cambiaron por "== default(DateTime)" porque es más fácil de evaluar así
- se creó la nueva clase "ConsultationDay" que almacena una fecha de futura consulta (se utiliza también como clave de comparación) y una lista de pacientes asignados a ese día, instancias de esa nueva clase se almacenan como valor T en los nodos del nuevo AVL y la inserción se hace en base a esa fecha
- cuando un nuevo paciente no especifica su futura fecha de regreso el proceso de inserción en el tercer AVL no se da, pero sí queda almacenado en los AVL generales de nombre y DPI
- Ya está agregada la validación de no más de 8 pacientes por día, en caso contrario se solicita una fecha diferente

IMPORTANTE: Aún falta añadir la funcionalidad de recalendarizar 